### PR TITLE
fix support for custom search and suggest

### DIFF
--- a/src/controls/MMapRouteControl/index.ts
+++ b/src/controls/MMapRouteControl/index.ts
@@ -170,6 +170,8 @@ class MMapCommonRouteControl extends mappable.MMapComplexEntity<MMapRouteControl
             inputPlaceholder: this._props.waypointsPlaceholders[waypointIndex],
             waypoint,
             geolocationTextInput: geolocationTextInput,
+            search: this._props.search,
+            suggest: this._props.suggest,
             onSelectWaypoint: (result) => {
                 if (result === null) {
                     this._waypoints[waypointIndex] = null;

--- a/src/controls/MMapSearchControl/MMapSuggest/index.ts
+++ b/src/controls/MMapSearchControl/MMapSuggest/index.ts
@@ -77,8 +77,8 @@ class MMapSuggest extends mappable.MMapComplexEntity<MMapSuggestProps> {
             element.classList.toggle(ACTIVE_CLASS, index === activeIndex);
         });
 
-        if (suggestElements[activeIndex] && suggestElements[activeIndex]?.dataset?.title) {
-            this._props.setSearchInputValue(suggestElements[activeIndex].dataset.title);
+        if (suggestElements[activeIndex] && suggestElements[activeIndex]?.dataset?.text) {
+            this._props.setSearchInputValue(suggestElements[activeIndex].dataset.text);
         }
     };
 
@@ -222,7 +222,7 @@ class MMapSuggestItem extends mappable.MMapComplexEntity<MMapSuggestItemProps> {
         this._rootElement.classList.add(SUGGEST_ITEM_CLASS);
         this._rootElement.tabIndex = -1;
         this._rootElement.addEventListener('click', this._props.onClick);
-        this._rootElement.dataset.title = this._props.suggestItem.title.text;
+        this._rootElement.dataset.text = this._props.suggestItem.title.text;
         if (this._props.suggestItem?.uri) {
             this._rootElement.dataset.uri = this._props.suggestItem.uri;
         }


### PR DESCRIPTION
1. I've thrown in custom `search` and `suggest` props
2. The `text` and `uri` properties now arrive in the search handler
