### PR TITLE
Fix input behavior in controls

### DIFF
--- a/src/controls/MMapRouteControl/MMapWaypointInput/index.ts
+++ b/src/controls/MMapRouteControl/MMapWaypointInput/index.ts
@@ -40,6 +40,9 @@ export type MMapWaypointInputProps = {
 
 const defaultProps = Object.freeze({geolocationTextInput: 'My location'});
 
+/**
+ * @internal
+ */
 export class MMapWaypointInput extends mappable.MMapComplexEntity<MMapWaypointInputProps, typeof defaultProps> {
     static defaultProps = defaultProps;
     private _detachDom?: DomDetach;
@@ -194,6 +197,7 @@ export class MMapWaypointInput extends mappable.MMapComplexEntity<MMapWaypointIn
 
     private _resetInput() {
         this._inputEl.value = '';
+        this._suggestComponent.update({searchInputValue: ''});
         this._updateIndicatorStatus('empty');
         this._props.onSelectWaypoint(null);
     }

--- a/src/controls/MMapSearchControl/MMapSuggest/index.ts
+++ b/src/controls/MMapSearchControl/MMapSuggest/index.ts
@@ -34,11 +34,11 @@ class MMapSuggest extends mappable.MMapComplexEntity<MMapSuggestProps> {
     }
 
     private _updateSuggest(props: Partial<MMapSuggestProps>) {
-        if (props.searchInputValue) {
+        if (props.searchInputValue !== undefined) {
             this._updateSuggestList(props.searchInputValue);
         }
 
-        if (props.suggestNavigationAction) {
+        if (props.suggestNavigationAction !== undefined) {
             this._updateActiveSuggest(props.suggestNavigationAction);
         }
     }


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `main` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
1. [x] After clearing the route input, we continue to show the digest for the previous request 
2. [ ] If the geosearch returned an error when selecting a route point from the digest, then we do not build a route and do not display any errors to the user at all 
3. [ ] When clearing the search input, we send another request to the digest with the previous text 
4. [ ] Firefox does not work selecting a point by clicking on the map
5. [ ] In Safari, clearing route inputs by clicking on the video cross does not work

