### PR TITLE
Add zoom props in geolocation control

### DIFF
--- a/example/controls/react/index.tsx
+++ b/example/controls/react/index.tsx
@@ -29,7 +29,7 @@ async function main() {
                 <MMapDefaultFeaturesLayer />
                 <MMapControls position="left">
                     <MMapZoomControl />
-                    <MMapGeolocationControl />
+                    <MMapGeolocationControl zoom={11} />
                 </MMapControls>
                 <MMapControls position="bottom">
                     <MMapZoomControl />

--- a/example/controls/vanilla/index.ts
+++ b/example/controls/vanilla/index.ts
@@ -15,7 +15,9 @@ async function main() {
         [new MMapDefaultSchemeLayer({}), new MMapDefaultFeaturesLayer({})]
     );
 
-    map.addChild(new MMapControls({position: 'left'}, [new MMapZoomControl({}), new MMapGeolocationControl({})]));
+    map.addChild(
+        new MMapControls({position: 'left'}, [new MMapZoomControl({}), new MMapGeolocationControl({zoom: 11})])
+    );
     map.addChild(new MMapControls({position: 'bottom'}, [new MMapZoomControl({})]));
     map.addChild(
         new MMapControls({position: 'right'}, [

--- a/example/controls/vue/index.ts
+++ b/example/controls/vue/index.ts
@@ -36,7 +36,7 @@ async function main() {
                 <MMapDefaultFeaturesLayer />
                 <MMapControls position="left">
                     <MMapZoomControl />
-                    <MMapGeolocationControl />
+                    <MMapGeolocationControl :zoom="11" />
                 </MMapControls>
                 <MMapControls position="bottom">
                     <MMapZoomControl />

--- a/src/controls/MMapGeolocationControl/index.ts
+++ b/src/controls/MMapGeolocationControl/index.ts
@@ -17,6 +17,8 @@ type MMapGeolocationControlProps = {
     easing?: EasingFunctionDescription;
     /** Map location animate duration */
     duration?: number;
+    /** Map zoom after geolocate position */
+    zoom?: number;
 };
 
 const defaultProps = Object.freeze({duration: 500});
@@ -28,7 +30,8 @@ const MMapGeolocationControlVuefyOptions: CustomVuefyOptions<MMapGeolocationCont
         onGeolocatePosition: Function as TVue.PropType<MMapGeolocationControlProps['onGeolocatePosition']>,
         source: String,
         easing: [String, Object, Function] as TVue.PropType<EasingFunctionDescription>,
-        duration: {type: Number, default: defaultProps.duration}
+        duration: {type: Number, default: defaultProps.duration},
+        zoom: {type: Number}
     }
 };
 
@@ -88,6 +91,7 @@ class MMapGeolocationControl extends mappable.MMapGroupEntity<MMapGeolocationCon
         map?.update({
             location: {
                 center: this._position,
+                zoom: this._props.zoom,
                 duration: this._props.duration,
                 easing: this._props.easing
             }

--- a/src/controls/MMapGeolocationControl/self.svg
+++ b/src/controls/MMapGeolocationControl/self.svg
@@ -1,1 +1,1 @@
-<svg width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 28c6.627 0 12-5.373 12-12S22.627 4 16 4 4 9.373 4 16s5.373 12 12 12Z" fill="#fff"/><path d="M16 25a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" fill="#F43"/></svg>
+<svg width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 28c6.627 0 12-5.373 12-12S22.627 4 16 4 4 9.373 4 16s5.373 12 12 12Z" fill="#fff"/><path d="M16 25a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" fill="#2E4CE5"/></svg>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `main` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
- Add `zoom` props in geolocation control. After clicking on the button, the map sets the specified zoom.
